### PR TITLE
fix issue with module path search running after proper path is located

### DIFF
--- a/modules/PoSHServer/PoSHServer.ps1
+++ b/modules/PoSHServer/PoSHServer.ps1
@@ -763,7 +763,15 @@ param (
 					if ($WindowsAuthentication -eq "On") { $Listener.AuthenticationSchemes = "IntegratedWindowsAuthentication"; }
 
 					# Open Connection
-					$Context = $Listener.GetContext()
+					$task = $Listener.GetContextAsync();
+                    while( -not $Context )
+                    {
+                        if( $task.Wait(500) )
+                        {
+				            $Context = $task.Result
+                        }
+                        sleep -Milliseconds 100;
+                    }
 					
 					# Authentication Module
 					. $PoSHModulePath\modules\authentication.ps1
@@ -1065,7 +1073,15 @@ param (
 				if ($WindowsAuthentication -eq "On") { $Listener.AuthenticationSchemes = "IntegratedWindowsAuthentication"; }
 
 				# Open Connection
-				$Context = $Listener.GetContext()
+                $task = $Listener.GetContextAsync();
+                while( -not $Context )
+                {
+                    if( $task.Wait(500) )
+                    {
+				        $Context = $task.Result
+                    }
+                    sleep -Milliseconds 100;
+                }
 				
 				# Authentication Module
 				. $PoSHModulePath\modules\authentication.ps1

--- a/modules/PoSHServer/PoSHServer.ps1
+++ b/modules/PoSHServer/PoSHServer.ps1
@@ -231,6 +231,7 @@ param (
 			if ($PoSHModulePathTest)
 			{
 				$PoSHModulePath = $ModulePath
+                break;
 			}
 		}
 	}


### PR DESCRIPTION
As it stands now, if you're using the PoshServer module from a location that isn't the last entry in $env:psmodulepath, the search logic fails incorrectly.  The issue is that the path test loop continues to run after the module path is found.  Adding the break on a successful path test fixes the issue.
